### PR TITLE
Allow ignoring parsed extra arguments if pydantic class tolerates it

### DIFF
--- a/pydantic_cli/__init__.py
+++ b/pydantic_cli/__init__.py
@@ -495,9 +495,9 @@ def _runner(
 
         # some Pydantic classes do tolerate extra arguments.
         if pargv:
-            if hasattr(cls.Config, "extra") and cls.Config.extra == Extra.ignore:
+            if cls.Config.extra == Extra.ignore:
                 pass
-            elif hasattr(cls.Config, "extra") and pargs.cls.Config.extra == Extra.allow:
+            elif cls.Config.extra == Extra.allow:
                 raise NotImplementedError("Extra.allow is not implemented")
             else:
                 # the default behavior of ArgumentParser is to not tolerate extra arguments

--- a/pydantic_cli/tests/test_examples_simple_with_shell_autocomplete_support.py
+++ b/pydantic_cli/tests/test_examples_simple_with_shell_autocomplete_support.py
@@ -20,7 +20,7 @@ class TestExamples(_TestHarness[Options]):
         if HAS_AUTOCOMPLETE_SUPPORT:
             args = ["--emit-completion", shell_id]
         else:
-            args = ["-i", "/path/to/file.txt", "-f", "1.0", "2"]
+            args = ["-i", "/path/to/file.txt", "-f", "1.0", "-m", "2"]
         self.run_config(args)
 
     def test_auto_complete_zsh(self):


### PR DESCRIPTION
Implements feature proposed in #40

By default, `ArgumentParser.parse_args` does not tolerate extra arguments.
This PR allows ignoring extra arguments when `Config.extra == Extra.ignore`.

When extra arguments are present and not tolerated, an error is raised, just like `ArgumentParser.parse_args` does.

Also fix a test that was failing only when shtab is not installed.