### PR TITLE
Add black pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,11 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 24.4.2
+    hooks:
+      - id: black
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: 'v1.10.1'
     hooks:
-    -   id: mypy
+      - id: mypy


### PR DESCRIPTION
Suggestion to also add the [black pre-commit hook](https://black.readthedocs.io/en/stable/integrations/source_version_control.html).