### PR TITLE
feat: added enum values when converting to pretty type

### DIFF
--- a/pydantic_cli/__init__.py
+++ b/pydantic_cli/__init__.py
@@ -7,6 +7,7 @@ import logging
 import typing
 from typing import overload
 from typing import Any, Mapping, Callable
+from enum import Enum
 
 
 import pydantic
@@ -92,10 +93,13 @@ def __try_to_pretty_type(field_type: Any) -> str:
             name = "|".join(map(lambda x: x.__name__, args))
     else:
         try:
-            name = field_type.__name__
+            name = field_type.__name__ + (
+                f"{[option.value for option in field_type]}"
+                if issubclass(field_type, Enum)
+                else ""
+            )
         except AttributeError:
             name = repr(field_type)
-
     return f"type:{name}"
 
 


### PR DESCRIPTION
Related to: https://github.com/mpkocher/pydantic-cli/issues/55

```py
from pydantic_cli import run_and_exit, Cmd

from enum import Enum

class MyEnum(Enum):
    a = 1
    b = 2
    c = 3


class Options(Cmd):
    input_file: MyEnum

    def run(self) -> None:
        print(f"Mock example running with {self}")

if __name__ == "__main__":
    run_and_exit(Options, description=__doc__, version="0.1.0")
```

Before:
```
--input_file INPUT_FILE    (type:MyEnum *required*)
```

After:
```
--input_file INPUT_FILE    (type:MyEnum[1, 2, 3] *required*)
```